### PR TITLE
Lean to the side

### DIFF
--- a/pink_balancer/config/common.gin
+++ b/pink_balancer/config/common.gin
@@ -6,6 +6,8 @@ import whole_body_controller
 
 HeightController.max_crouch_height = 0.08         # [m]
 HeightController.max_crouch_velocity = 0.05       # [m] / [s]
+HeightController.max_height_difference = 0.02     # [m]
+HeightController.max_lean_velocity = 0.04         # [m] / [s]
 HeightController.visualize = False
 
 WheelBalancer.air_return_period = 1.0             # [s]

--- a/pink_balancer/height_controller.py
+++ b/pink_balancer/height_controller.py
@@ -217,7 +217,7 @@ class HeightController:
             velocity = self.max_crouch_velocity * axis_value
         except KeyError:
             velocity = 0.0
-        
+
         height = self.target_height
         height += velocity * dt
         return height
@@ -378,7 +378,7 @@ class HeightController:
             self.configuration,
             self.tasks.values(),
             dt,
-            solver="cvxopt",
+            solver="proxqp",
         )
         self.configuration.integrate_inplace(velocity, dt)
         self.last_velocity = velocity

--- a/pink_balancer/height_controller.py
+++ b/pink_balancer/height_controller.py
@@ -289,7 +289,7 @@ class HeightController:
             )
             transform_target_to_common = pin.SE3(
                 rotation=np.eye(3),
-                translation=self.target_offset[target]
+                translation=self.target_offset[target],
             )
             transform_target_to_world = (
                 self.transform_rest_to_world[target]

--- a/pink_balancer/height_controller.py
+++ b/pink_balancer/height_controller.py
@@ -353,8 +353,8 @@ class HeightController:
         """
         return {
             "configuration": self.configuration.q,
-            "left_target_height": self.target_position_wheel_in_rest['left_contact'][2],
-            "right_target_height": self.target_position_wheel_in_rest['right_contact'][2],
+            "target_height": self.target_height,
+            "height_difference": self.height_difference,
             "velocity": self.last_velocity,
         }
 


### PR DESCRIPTION
This PR adds the option to lean to the side. We map the horizontal buttons on the joystick to a scalar called `height_difference` that offsets the target height of each wheel frame (with alternating signs).
![leaning](https://github.com/user-attachments/assets/47c4fd6c-ca4f-4aed-b7ee-ec01cc36290e)

