### PR TITLE
Add MPC sagittal balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ An agent for [Upkie](https://github.com/upkie/upkie/) that combines wheeled bala
 - Upload this repository to your Upkie: ``make upload``
 - Run the pi3hat spine: ``pi3hat_spine`` (on your robot)
 - Run the agent: ``python pink_balancer/main.py -c $(hostname)``
+
+## Configuration tweaks
+
+- Select the MPC or PI sagittal balancer in `WheelController.balancer_class`

--- a/config/base.gin
+++ b/config/base.gin
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-BalancingGains.pitch_damping = 10.0
-BalancingGains.pitch_stiffness = 20.0
-BalancingGains.position_damping = 5.0
-BalancingGains.position_stiffness = 2.0
+PIBalancerGains.pitch_damping = 10.0
+PIBalancerGains.pitch_stiffness = 20.0
+PIBalancerGains.position_damping = 5.0
+PIBalancerGains.position_stiffness = 2.0
 
 HeightController.max_crouch_height = 0.08           # [m]
 HeightController.max_crouch_velocity = 0.05         # [m] / [s]
@@ -13,10 +13,10 @@ HeightController.max_height_difference = 0.02       # [m]
 HeightController.max_lean_velocity = 0.04           # [m] / [s]
 HeightController.visualize = False
 
-PIWheelBalancer.air_return_period = 1.0             # [s]
-PIWheelBalancer.fall_pitch = 1.0                    # [rad]
-PIWheelBalancer.max_integral_error_velocity = 10.0  # [m] / [s]
-PIWheelBalancer.max_target_distance = 1.0           # [m]
+PIBalancer.air_return_period = 1.0             # [s]
+PIBalancer.fall_pitch = 1.0                    # [rad]
+PIBalancer.max_integral_error_velocity = 10.0  # [m] / [s]
+PIBalancer.max_target_distance = 1.0           # [m]
 
 WheelBalancer.max_ground_velocity = 1.0             # [m] / [s]
 WheelBalancer.max_target_accel = 0.3                # [m] / [s]²

--- a/config/base.gin
+++ b/config/base.gin
@@ -18,14 +18,14 @@ PIBalancer.fall_pitch = 1.0                    # [rad]
 PIBalancer.max_integral_error_velocity = 10.0  # [m] / [s]
 PIBalancer.max_target_distance = 1.0           # [m]
 
-WheelBalancer.max_ground_velocity = 1.0             # [m] / [s]
-WheelBalancer.max_target_accel = 0.3                # [m] / [s]²
-WheelBalancer.max_target_velocity = 0.6             # [m] / [s]
-WheelBalancer.max_yaw_accel = 10.0                  # [rad] / [s]²
-WheelBalancer.max_yaw_velocity = 1.0                # [rad] / [s]
-WheelBalancer.turning_deadband = 0.3
-WheelBalancer.turning_decision_time = 0.2           # [s]
-WheelBalancer.wheel_radius = 0.06                   # [m]
+WheelController.max_ground_velocity = 1.0             # [m] / [s]
+WheelController.max_target_accel = 0.3                # [m] / [s]²
+WheelController.max_target_velocity = 0.6             # [m] / [s]
+WheelController.max_yaw_accel = 10.0                  # [rad] / [s]²
+WheelController.max_yaw_velocity = 1.0                # [rad] / [s]
+WheelController.turning_deadband = 0.3
+WheelController.turning_decision_time = 0.2           # [s]
+WheelController.wheel_radius = 0.06                   # [m]
 
 WholeBodyController.gain_scale = 2.0
 WholeBodyController.turning_gain_scale = 2.0

--- a/config/base.gin
+++ b/config/base.gin
@@ -2,24 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-HeightController.max_crouch_height = 0.08         # [m]
-HeightController.max_crouch_velocity = 0.05       # [m] / [s]
-HeightController.max_height_difference = 0.02     # [m]
-HeightController.max_lean_velocity = 0.04         # [m] / [s]
+BalancingGains.pitch_damping = 10.0
+BalancingGains.pitch_stiffness = 20.0
+BalancingGains.position_damping = 5.0
+BalancingGains.position_stiffness = 2.0
+
+HeightController.max_crouch_height = 0.08           # [m]
+HeightController.max_crouch_velocity = 0.05         # [m] / [s]
+HeightController.max_height_difference = 0.02       # [m]
+HeightController.max_lean_velocity = 0.04           # [m] / [s]
 HeightController.visualize = False
 
-WheelBalancer.air_return_period = 1.0             # [s]
-WheelBalancer.fall_pitch = 1.0                    # [rad]
-WheelBalancer.max_ground_velocity = 1.0           # [m] / [s]
-WheelBalancer.max_integral_error_velocity = 10.0  # [m] / [s]
-WheelBalancer.max_target_accel = 0.3              # [m] / [s]²
-WheelBalancer.max_target_distance = 1.0           # [m]
-WheelBalancer.max_target_velocity = 0.6           # [m] / [s]
-WheelBalancer.max_yaw_accel = 10.0                # [rad] / [s]²
-WheelBalancer.max_yaw_velocity = 1.0              # [rad] / [s]
+PIWheelBalancer.air_return_period = 1.0             # [s]
+PIWheelBalancer.fall_pitch = 1.0                    # [rad]
+PIWheelBalancer.max_integral_error_velocity = 10.0  # [m] / [s]
+PIWheelBalancer.max_target_distance = 1.0           # [m]
+
+WheelBalancer.max_ground_velocity = 1.0             # [m] / [s]
+WheelBalancer.max_target_accel = 0.3                # [m] / [s]²
+WheelBalancer.max_target_velocity = 0.6             # [m] / [s]
+WheelBalancer.max_yaw_accel = 10.0                  # [rad] / [s]²
+WheelBalancer.max_yaw_velocity = 1.0                # [rad] / [s]
 WheelBalancer.turning_deadband = 0.3
-WheelBalancer.turning_decision_time = 0.2         # [s]
-WheelBalancer.wheel_radius = 0.06                 # [m]
+WheelBalancer.turning_decision_time = 0.2           # [s]
+WheelBalancer.wheel_radius = 0.06                   # [m]
 
 WholeBodyController.gain_scale = 2.0
 WholeBodyController.turning_gain_scale = 2.0

--- a/config/base.gin
+++ b/config/base.gin
@@ -7,25 +7,39 @@ PIBalancerGains.pitch_stiffness = 20.0
 PIBalancerGains.position_damping = 5.0
 PIBalancerGains.position_stiffness = 2.0
 
-HeightController.max_crouch_height = 0.08           # [m]
-HeightController.max_crouch_velocity = 0.05         # [m] / [s]
-HeightController.max_height_difference = 0.02       # [m]
-HeightController.max_lean_velocity = 0.04           # [m] / [s]
+HeightController.max_crouch_height = 0.08            # [m]
+HeightController.max_crouch_velocity = 0.05          # [m] / [s]
+HeightController.max_height_difference = 0.02        # [m]
+HeightController.max_lean_velocity = 0.04            # [m] / [s]
 HeightController.visualize = False
 
-PIBalancer.air_return_period = 1.0             # [s]
-PIBalancer.fall_pitch = 1.0                    # [rad]
-PIBalancer.max_integral_error_velocity = 10.0  # [m] / [s]
-PIBalancer.max_target_distance = 1.0           # [m]
+MPCBalancer.leg_length = 0.58                        # [m]
+MPCBalancer.nb_timesteps = 50
+MPCBalancer.sampling_period = 0.02                   # [s]
+MPCBalancer.stage_input_cost_weight = 1e-3
+MPCBalancer.stage_state_cost_weight = 1e-3
+MPCBalancer.terminal_cost_weight = 1.0
+MPCBalancer.warm_start = True
 
-WheelController.max_ground_velocity = 1.0             # [m] / [s]
-WheelController.max_target_accel = 0.3                # [m] / [s]²
-WheelController.max_target_velocity = 0.6             # [m] / [s]
-WheelController.max_yaw_accel = 10.0                  # [rad] / [s]²
-WheelController.max_yaw_velocity = 1.0                # [rad] / [s]
+PIBalancer.air_return_period = 1.0                   # [s]
+PIBalancer.fall_pitch = 1.0                          # [rad]
+PIBalancer.max_integral_error_velocity = 10.0        # [m] / [s]
+PIBalancer.max_target_distance = 1.0                 # [m]
+
+ProxQPWorkspace.update_preconditioner = True
+ProxQPWorkspace.verbose = False
+
+SagittalBalancer.max_ground_accel = 10.0             # [m] / [s]²
+SagittalBalancer.max_ground_velocity = 1.0           # [m] / [s]
+
+WheelController.balancer_class = "MPCBalancer"
+WheelController.max_target_accel = 0.3               # [m] / [s]²
+WheelController.max_target_velocity = 0.6            # [m] / [s]
+WheelController.max_yaw_accel = 10.0                 # [rad] / [s]²
+WheelController.max_yaw_velocity = 1.0               # [rad] / [s]
 WheelController.turning_deadband = 0.3
-WheelController.turning_decision_time = 0.2           # [s]
-WheelController.wheel_radius = 0.06                   # [m]
+WheelController.turning_decision_time = 0.2          # [s]
+WheelController.wheel_radius = 0.06                  # [m]
 
 WholeBodyController.gain_scale = 2.0
 WholeBodyController.turning_gain_scale = 2.0

--- a/config/bullet.gin
+++ b/config/bullet.gin
@@ -2,16 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-BalancingGains.pitch_damping = 10.0
-BalancingGains.pitch_stiffness = 20.0
-BalancingGains.position_damping = 5.0
-BalancingGains.position_stiffness = 2.0
-
-WheelBalancer.max_ground_velocity = 2.0           # [m] / [s]
-
 # The maximum target distance should be set above the steady-state position
 # error of the current set of gains, otherwise the robot will keep rolling even
 # though it is able to balance itself. Empirically in Bullet with the gains
 # above the steady-state error is around 1.2 meters with straight legs and 1.5
 # meters at full crouch.
-WheelBalancer.max_target_distance = 1.5           # [m]
+PIWheelBalancer.max_target_distance = 1.5         # [m]
+
+WheelBalancer.max_ground_velocity = 2.0           # [m] / [s]

--- a/config/bullet.gin
+++ b/config/bullet.gin
@@ -7,6 +7,6 @@
 # though it is able to balance itself. Empirically in Bullet with the gains
 # above the steady-state error is around 1.2 meters with straight legs and 1.5
 # meters at full crouch.
-PIWheelBalancer.max_target_distance = 1.5         # [m]
+PIBalancer.max_target_distance = 1.5         # [m]
 
 WheelBalancer.max_ground_velocity = 2.0           # [m] / [s]

--- a/config/bullet.gin
+++ b/config/bullet.gin
@@ -9,4 +9,4 @@
 # meters at full crouch.
 PIBalancer.max_target_distance = 1.5         # [m]
 
-WheelBalancer.max_ground_velocity = 2.0           # [m] / [s]
+WheelController.max_ground_velocity = 2.0           # [m] / [s]

--- a/config/bullet.gin
+++ b/config/bullet.gin
@@ -7,6 +7,6 @@
 # though it is able to balance itself. Empirically in Bullet with the gains
 # above the steady-state error is around 1.2 meters with straight legs and 1.5
 # meters at full crouch.
-PIBalancer.max_target_distance = 1.5         # [m]
+PIBalancer.max_target_distance = 1.5                 # [m]
 
-WheelController.max_ground_velocity = 2.0           # [m] / [s]
+SagittalBalancer.max_ground_velocity = 2.0           # [m] / [s]

--- a/config/michel-strogoff.gin
+++ b/config/michel-strogoff.gin
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-WheelBalancer.wheel_radius = 0.055  # [m]
-
 BalancingGains.pitch_damping = 1.8
 BalancingGains.pitch_stiffness = 20.0
 BalancingGains.position_damping = 0.7
 BalancingGains.position_stiffness = 1.6
+
+WheelBalancer.wheel_radius = 0.055  # [m]

--- a/config/michel-strogoff.gin
+++ b/config/michel-strogoff.gin
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-BalancingGains.pitch_damping = 1.8
-BalancingGains.pitch_stiffness = 20.0
-BalancingGains.position_damping = 0.7
-BalancingGains.position_stiffness = 1.6
+PIBalancerGains.pitch_damping = 1.8
+PIBalancerGains.pitch_stiffness = 20.0
+PIBalancerGains.position_damping = 0.7
+PIBalancerGains.position_stiffness = 1.6
 
 WheelBalancer.wheel_radius = 0.055  # [m]

--- a/config/michel-strogoff.gin
+++ b/config/michel-strogoff.gin
@@ -7,4 +7,4 @@ PIBalancerGains.pitch_stiffness = 20.0
 PIBalancerGains.position_damping = 0.7
 PIBalancerGains.position_stiffness = 1.6
 
-WheelBalancer.wheel_radius = 0.055  # [m]
+WheelController.wheel_radius = 0.055  # [m]

--- a/config/upkie-zero.gin
+++ b/config/upkie-zero.gin
@@ -7,12 +7,12 @@ import whole_body_controller
 # Pitch gains: 2 is roughly the good damping value for a stiffness of 15; 1 is
 # too low, resulting in oscillations of increasing magnitude; 3 is too high,
 # resulting in permanent small oscillations as the robot rolls around.
-BalancingGains.pitch_damping = 2.0
-BalancingGains.pitch_stiffness = 15.0
+PIBalancerGains.pitch_damping = 2.0
+PIBalancerGains.pitch_stiffness = 15.0
 
 # Position gains: 2.5 is roughly a good value to match the (2, 15) in pitch;
 # 1.6 is also good on rough horizontal floor, 3.3 is too much and results in
 # oscillations of increasing magnitude. Going for 1.6 now because 2.5 feels a
 # bit more overshooty.
-BalancingGains.position_damping = 0.8
-BalancingGains.position_stiffness = 1.6
+PIBalancerGains.position_damping = 0.8
+PIBalancerGains.position_stiffness = 1.6

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,8 +2,9 @@ name: pink_balancer
 channels:
     - conda-forge
 dependencies:
-    - gin-config >=0.5.0
-    - pinocchio >=3.1.0
-    - qpsolvers >=4.2.0
-    - pink >=3.0.0
-    - upkie >=5.1.0
+    - gin-config >= 0.5.0
+    - pinocchio >= 3.1.0
+    - qpmpc >= 3.0.1
+    - qpsolvers >= 4.2.0
+    - pink >= 3.0.0
+    - upkie >= 5.1.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - gin-config >=0.5.0
-    - pinocchio >=2.6.21
+    - pinocchio >=3.1.0
     - qpsolvers >=4.2.0
     - pink >=3.0.0
-    - upkie >=5.0.0
+    - upkie >=5.1.0

--- a/pink_balancer/pi_wheel_balancer.py
+++ b/pink_balancer/pi_wheel_balancer.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Stéphane Caron
+# Copyright 2023 Inria
+
+import gin
+import numpy as np
+from upkie.exceptions import FallDetected
+from upkie.utils.clamp import clamp, clamp_abs
+from upkie.utils.filters import low_pass_filter
+
+from .balancing_gains import BalancingGains
+from .wheel_balancer import WheelBalancer
+
+
+@gin.configurable
+class PIWheelBalancer(WheelBalancer):
+    """
+    Balancing by proportional-integrative feedback of the base pitch error and
+    ground position error to wheel velocities.
+
+    Attributes:
+        air_return_period: Cutoff period for resetting integrators while the
+            robot is in the air, in [s].
+        error: Two-dimensional vector of ground position and base pitch errors.
+        gains: Velocity controller gains.
+        max_integral_error_velocity: Maximum integral error velocity, in
+            [m] / [s].
+        max_target_distance: Maximum distance from the current ground position
+            to the target, in [m].
+        target_ground_position: Target ground sagittal position in [m].
+    """
+
+    air_return_period: float
+    error: np.ndarray
+    gains: BalancingGains
+    max_integral_error_velocity: float
+    max_target_distance: float
+    target_ground_position: float
+
+    def __init__(
+        self,
+        air_return_period: float,
+        fall_pitch: float,
+        max_integral_error_velocity: float,
+        max_target_distance: float,
+    ):
+        """
+        Initialize balancer.
+
+        Args:
+            air_return_period: Cutoff period for resetting integrators while
+                the robot is in the air, in [s].
+            max_integral_error_velocity: Maximum integral error velocity, in
+                [m] / [s].
+            max_target_distance: Maximum distance from the current ground
+                position to the target, in [m].
+        """
+        super().__init__()
+        self.air_return_period = air_return_period
+        self.error = np.zeros(2)
+        self.fall_pitch = fall_pitch
+        self.gains = BalancingGains()
+        self.max_integral_error_velocity = max_integral_error_velocity
+        self.max_target_distance = max_target_distance
+        self.target_ground_position = 0.0
+
+    def process_joystick_buttons(self, observation: dict) -> None:
+        """
+        Process joystick buttons.
+
+        Args:
+            observation: Latest observation.
+        """
+        super().process_joystick_buttons(observation)
+        ground_position = observation["wheel_odometry"]["position"]
+        try:
+            if observation["joystick"]["cross_button"]:
+                # When the user presses the reset button, we assume there is no
+                # contact for sure (or we are in a situation where spinning the
+                # wheels is dangerous?) and thus perform a hard rather than
+                # soft reset of both integrators.
+                self.integral_error_velocity = 0.0  # [m] / [s]
+                self.target_ground_position = ground_position
+        except KeyError:
+            pass
+
+    def compute_ground_velocity(self, observation: dict, dt: float) -> float:
+        """
+        Compute a new ground velocity.
+
+        Args:
+            observation: Latest observation.
+            dt: Time in [s] until next cycle.
+
+        Returns:
+            New ground velocity, in [m] / [s].
+        """
+        pitch = observation["base_orientation"]["pitch"]
+        if abs(pitch) > self.fall_pitch:
+            self.integral_error_velocity = 0.0  # [m] / [s]
+            self.ground_velocity = 0.0  # [m] / [s]
+            raise FallDetected(f"Base angle {pitch=:.3} rad denotes a fall")
+
+        ground_position = observation["wheel_odometry"]["position"]
+        floor_contact = observation["floor_contact"]["contact"]
+
+        target_pitch: float = 0.0  # [rad]
+        error = np.array(
+            [
+                self.target_ground_position - ground_position,
+                target_pitch - pitch,
+            ]
+        )
+        self.error = error
+
+        if not floor_contact:
+            self.integral_error_velocity = low_pass_filter(
+                self.integral_error_velocity, self.air_return_period, 0.0, dt
+            )
+            # We don't reset self.target_ground_velocity: either takeoff
+            # detection is a false positive and we should resume close to the
+            # pre-takeoff state, or the robot is really in the air and the user
+            # should stop smashing the joystick like a bittern ;p
+            self.target_ground_position = low_pass_filter(
+                self.target_ground_position,
+                self.air_return_period,
+                ground_position,
+                dt,
+            )
+        else:  # floor_contact:
+            ki = np.array(
+                [
+                    self.gains.position_stiffness,
+                    self.gains.pitch_stiffness,
+                ]
+            )
+            self.integral_error_velocity += ki.dot(error) * dt
+            self.integral_error_velocity = clamp_abs(
+                self.integral_error_velocity, self.max_integral_error_velocity
+            )
+            self.target_ground_position += self.target_ground_velocity * dt
+            self.target_ground_position = clamp(
+                self.target_ground_position,
+                ground_position - self.max_target_distance,
+                ground_position + self.max_target_distance,
+            )
+
+        kp = np.array(
+            [
+                self.gains.position_damping,
+                self.gains.pitch_damping,
+            ]
+        )
+
+        # Non-minimum phase trick: as per control theory's book, the proper
+        # feedforward velocity should be ``+self.target_ground_velocity``.
+        # However, it is with resolute purpose that it sends
+        # ``-self.target_ground_velocity`` instead!
+        #
+        # Try both on the robot, you will see the difference :)
+        #
+        # This hack is not purely out of "esprit de contradiction". Changing
+        # velocity is a non-minimum phase behavior (to accelerate forward, the
+        # ZMP of the LIPM needs to move backward at first, then forward), and
+        # our feedback can't realize that (it only takes care of balancing
+        # around a stationary velocity).
+        #
+        # What's left? Our integrator! If we send the opposite of the target
+        # velocity (or only a fraction of it, although 100% seems to do a good
+        # job), Upkie will immediately start executing the desired non-minimum
+        # phase behavior. The error will then grow and the integrator catch up
+        # so that ``upkie_trick_velocity - self.integral_error_velocity``
+        # converges to its proper steady state value (the same value ``0 -
+        # self.integral_error_velocity`` would have converged to if we had no
+        # feedforward).
+        #
+        # Unconvinced? Try it on the robot. You will feel Upkie's trick ;)
+        #
+        upkie_trick_velocity = -self.target_ground_velocity
+
+        self.ground_velocity = (
+            upkie_trick_velocity - kp.dot(error) - self.integral_error_velocity
+        )
+        self.ground_velocity = clamp_abs(
+            self.ground_velocity, self.max_ground_velocity
+        )
+        return self.ground_velocity
+
+    def log(self) -> dict:
+        """
+        Log internal state to a dictionary.
+
+        Returns:
+            Log data as a dictionary.
+        """
+        log_dict = super().log()
+        log_dict.update(
+            {
+                "error": self.error,
+                "gains": self.gains.__dict__,
+                "ground_velocity": self.ground_velocity,
+                "integral_error_velocity": self.integral_error_velocity,
+                "target_ground_position": self.target_ground_position,
+            }
+        )
+        return log_dict

--- a/pink_balancer/sagittal_balance/__init__.py
+++ b/pink_balancer/sagittal_balance/__init__.py
@@ -5,7 +5,9 @@
 # Copyright 2024 Inria
 
 from .pi_balancer import PIBalancer
+from .sagittal_balancer import SagittalBalancer
 
 __all__ = [
     "PIBalancer",
+    "SagittalBalancer",
 ]

--- a/pink_balancer/sagittal_balance/__init__.py
+++ b/pink_balancer/sagittal_balance/__init__.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Inria
 
+from .mpc_balancer import MPCBalancer
 from .pi_balancer import PIBalancer
 from .sagittal_balancer import SagittalBalancer
 
 __all__ = [
+    "MPCBalancer",
     "PIBalancer",
     "SagittalBalancer",
 ]

--- a/pink_balancer/sagittal_balance/__init__.py
+++ b/pink_balancer/sagittal_balance/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Inria
+
+from .pi_balancer import PIBalancer
+
+__all__ = [
+    "PIBalancer",
+]

--- a/pink_balancer/sagittal_balance/mpc_balancer.py
+++ b/pink_balancer/sagittal_balance/mpc_balancer.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 Inria
+
+"""Wheel balancing using model predictive control with the ProxQP solver."""
+
+import gin
+import numpy as np
+from qpmpc import MPCQP, Plan
+from qpmpc.systems import WheeledInvertedPendulum
+from qpsolvers import solve_problem
+from upkie.utils.clamp import clamp_and_warn
+from upkie.utils.filters import low_pass_filter
+from upkie.utils.spdlog import logging
+
+from .proxqp_workspace import ProxQPWorkspace
+from .sagittal_balancer import SagittalBalancer
+
+
+@gin.configurable
+class MPCBalancer(SagittalBalancer):
+    def __init__(
+        self,
+        leg_length: float,
+        nb_timesteps: int,
+        sampling_period: float,
+        stage_input_cost_weight: float,
+        stage_state_cost_weight: float,
+        terminal_cost_weight: float,
+        warm_start: bool,
+    ):
+        """
+        Initialize balancer.
+
+        Args:
+            leg_length: Leg length in [m].
+            stage_input_cost_weight: Weight for the stage input cost.
+            stage_state_cost_weight: Weight for the stage state cost.
+            terminal_cost_weight: Weight for the terminal cost.
+            warm_start: If set, use the warm-starting feature of ProxQP.
+        """
+        super().__init__()
+        max_ground_accel = self.max_ground_accel  # from parent ctor
+        pendulum = WheeledInvertedPendulum(
+            length=leg_length,
+            max_ground_accel=max_ground_accel,
+            nb_timesteps=nb_timesteps,
+            sampling_period=sampling_period,
+        )
+        mpc_problem = pendulum.build_mpc_problem(
+            terminal_cost_weight=terminal_cost_weight,
+            stage_state_cost_weight=stage_state_cost_weight,
+            stage_input_cost_weight=stage_input_cost_weight,
+        )
+        mpc_problem.initial_state = np.zeros(4)
+        mpc_qp = MPCQP(mpc_problem)
+        workspace = ProxQPWorkspace(mpc_qp)
+        self.commanded_velocity = 0.0
+        self.mpc_problem = mpc_problem
+        self.mpc_qp = mpc_qp
+        self.pendulum = pendulum
+        self.warm_start = warm_start
+        self.workspace = workspace
+
+    def compute_ground_velocity(
+        self,
+        target_ground_velocity: float,
+        observation: dict,
+        dt: float,
+    ) -> float:
+        """
+        Compute a new ground velocity.
+
+        Args:
+            target_ground_velocity: Target ground velocity in [m] / [s].
+            observation: Latest observation dictionary.
+            dt: Time in [s] until next cycle.
+
+        Returns:
+            New ground velocity, in [m] / [s].
+        """
+        floor_contact = observation["floor_contact"]["contact"]
+        base_orientation = observation["base_orientation"]
+        base_pitch = base_orientation["pitch"]
+        base_angular_velocity = base_orientation["angular_velocity"][1]
+        ground_position = observation["wheel_odometry"]["position"]
+        ground_velocity = observation["wheel_odometry"]["velocity"]
+
+        initial_state = np.array(
+            [
+                ground_position,
+                base_pitch,
+                ground_velocity,
+                base_angular_velocity,
+            ]
+        )
+
+        nx = WheeledInvertedPendulum.STATE_DIM
+        target_states = np.zeros((self.pendulum.nb_timesteps + 1) * nx)
+        self.mpc_problem.update_initial_state(initial_state)
+        self.mpc_problem.update_goal_state(target_states[-nx:])
+        self.mpc_problem.update_target_states(target_states[:-nx])
+
+        self.mpc_qp.update_cost_vector(self.mpc_problem)
+        if self.warm_start:
+            qpsol = self.workspace.solve(self.mpc_qp)
+        else:  # not self.warm_start
+            qpsol = solve_problem(self.mpc_qp.problem, solver="proxqp")
+        if not qpsol.found:
+            logging.warn("No solution found to the MPC problem")
+        plan = Plan(self.mpc_problem, qpsol)
+
+        if not floor_contact:
+            self.commanded_velocity = low_pass_filter(
+                prev_output=target_ground_velocity,
+                cutoff_period=0.1,
+                new_input=0.0,
+                dt=dt,
+            )
+        elif plan.is_empty:
+            logging.error("Solver found no solution to the MPC problem")
+            logging.info("Re-sending previous ground velocity")
+        else:  # plan was found
+            self.pendulum.state = initial_state
+            commanded_accel = plan.first_input[0]
+            self.commanded_velocity = clamp_and_warn(
+                self.commanded_velocity + commanded_accel * dt / 2.0,
+                lower=-1.0,
+                upper=+1.0,
+                label="commanded_velocity",
+            )
+        return self.commanded_velocity
+
+    def log(self) -> dict:
+        """
+        Log internal state to a dictionary.
+
+        Returns:
+            Log data as a dictionary.
+        """
+        return {
+            "commanded_velocity": self.commanded_velocity,
+        }

--- a/pink_balancer/sagittal_balance/mpc_balancer.py
+++ b/pink_balancer/sagittal_balance/mpc_balancer.py
@@ -66,7 +66,7 @@ class MPCBalancer(SagittalBalancer):
 
     def compute_ground_velocity(
         self,
-        target_ground_velocity: float,
+        target_ground_velocity: float,  # TODO(scaron): use this
         observation: dict,
         dt: float,
     ) -> float:
@@ -114,7 +114,7 @@ class MPCBalancer(SagittalBalancer):
 
         if not floor_contact:
             self.commanded_velocity = low_pass_filter(
-                prev_output=target_ground_velocity,
+                prev_output=self.commanded_velocity,
                 cutoff_period=0.1,
                 new_input=0.0,
                 dt=dt,

--- a/pink_balancer/sagittal_balance/pi_balancer.py
+++ b/pink_balancer/sagittal_balance/pi_balancer.py
@@ -12,10 +12,11 @@ from upkie.utils.clamp import clamp, clamp_abs
 from upkie.utils.filters import low_pass_filter
 
 from .pi_balancer_gains import PIBalancerGains
+from .sagittal_balancer import SagittalBalancer
 
 
 @gin.configurable
-class PIBalancer:
+class PIBalancer(SagittalBalancer):
     """
     Balancing by proportional-integrative feedback of the base pitch error and
     ground position error to wheel velocities.

--- a/pink_balancer/sagittal_balance/pi_balancer_gains.py
+++ b/pink_balancer/sagittal_balance/pi_balancer_gains.py
@@ -9,7 +9,7 @@ import gin
 
 
 @gin.configurable
-class BalancingGains:
+class PIBalancerGains:
     pitch_damping: float
     pitch_stiffness: float
     position_damping: float
@@ -62,7 +62,7 @@ class BalancingGains:
 
     def __repr__(self):
         return (
-            "BalancingGains("
+            "PIBalancerGains("
             f"pitch_damping={self.pitch_damping}, "
             f"pitch_stiffness={self.pitch_stiffness}, "
             f"position_damping={self.position_damping}, "

--- a/pink_balancer/sagittal_balance/proxqp_workspace.py
+++ b/pink_balancer/sagittal_balance/proxqp_workspace.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Inria
+
+import gin
+import qpsolvers
+from proxsuite import proxqp
+from qpmpc import MPCQP
+
+
+@gin.configurable
+class ProxQPWorkspace:
+    def __init__(
+        self, mpc_qp: MPCQP, update_preconditioner: bool, verbose: bool
+    ):
+        n_eq = 0
+        n_in = mpc_qp.h.size // 2  # WheeledInvertedPendulum structure
+        n = mpc_qp.P.shape[1]
+        solver = proxqp.dense.QP(
+            n,
+            n_eq,
+            n_in,
+            dense_backend=proxqp.dense.DenseBackend.PrimalDualLDLT,
+        )
+        solver.settings.eps_abs = 1e-3
+        solver.settings.eps_rel = 0.0
+        solver.settings.verbose = verbose
+        solver.settings.compute_timings = True
+        solver.settings.primal_infeasibility_solving = True
+        solver.init(
+            H=mpc_qp.P,
+            g=mpc_qp.q,
+            C=mpc_qp.G[::2, :],  # WheeledInvertedPendulum structure
+            l=-mpc_qp.h[1::2],  # WheeledInvertedPendulum structure
+            u=mpc_qp.h[::2],  # WheeledInvertedPendulum structure
+        )
+        solver.solve()
+        self.update_preconditioner = update_preconditioner
+        self.solver = solver
+
+    def solve(self, mpc_qp: MPCQP) -> qpsolvers.Solution:
+        self.solver.update(
+            g=mpc_qp.q,
+            update_preconditioner=self.update_preconditioner,
+        )
+        self.solver.solve()
+        result = self.solver.results
+        qpsol = qpsolvers.Solution(mpc_qp.problem)
+        qpsol.found = result.info.status == proxqp.QPSolverOutput.PROXQP_SOLVED
+        qpsol.x = self.solver.results.x
+        return qpsol

--- a/pink_balancer/sagittal_balance/sagittal_balancer.py
+++ b/pink_balancer/sagittal_balance/sagittal_balancer.py
@@ -6,8 +6,28 @@
 
 import abc
 
+import gin
 
+
+@gin.configurable
 class SagittalBalancer(abc.ABC):
+    def __init__(
+        self,
+        max_ground_accel: float,
+        max_ground_velocity: float,
+    ):
+        """
+        Initialize balancer.
+
+        Args:
+            max_ground_accel: Maximum commanded ground acceleration no matter
+                what, in [m] / [s]².
+            max_ground_velocity: Maximum commanded ground velocity no matter
+                what, in [m] / [s].
+        """
+        self.max_ground_accel = max_ground_accel
+        self.max_ground_velocity = max_ground_velocity
+
     @abc.abstractmethod
     def compute_ground_velocity(
         self,
@@ -35,10 +55,4 @@ class SagittalBalancer(abc.ABC):
         Returns:
             Log data as a dictionary.
         """
-        return {
-            "error": self.error,
-            "gains": self.gains.__dict__,
-            "ground_velocity": self.ground_velocity,
-            "integral_error_velocity": self.integral_error_velocity,
-            "target_ground_position": self.target_ground_position,
-        }
+        return {}

--- a/pink_balancer/sagittal_balance/sagittal_balancer.py
+++ b/pink_balancer/sagittal_balance/sagittal_balancer.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Inria
+
+import abc
+
+
+class SagittalBalancer(abc.ABC):
+    @abc.abstractmethod
+    def compute_ground_velocity(
+        self,
+        target_ground_velocity: float,
+        observation: dict,
+        dt: float,
+    ) -> float:
+        """
+        Compute a new ground velocity.
+
+        Args:
+            target_ground_velocity: Target ground velocity in [m] / [s].
+            observation: Latest observation dictionary.
+            dt: Time in [s] until next cycle.
+
+        Returns:
+            New ground velocity, in [m] / [s].
+        """
+
+    @abc.abstractmethod
+    def log(self) -> dict:
+        """
+        Log internal state to a dictionary.
+
+        Returns:
+            Log data as a dictionary.
+        """
+        return {
+            "error": self.error,
+            "gains": self.gains.__dict__,
+            "ground_velocity": self.ground_velocity,
+            "integral_error_velocity": self.integral_error_velocity,
+            "target_ground_position": self.target_ground_position,
+        }

--- a/pink_balancer/wheel_controller.py
+++ b/pink_balancer/wheel_controller.py
@@ -12,11 +12,11 @@ import numpy as np
 from upkie.utils.clamp import clamp_abs
 from upkie.utils.filters import abs_bounded_derivative_filter
 
-from .sagittal_balance import PIBalancer
+from .sagittal_balance import PIBalancer, SagittalBalancer
 
 
 @gin.configurable
-class WheelBalancer:
+class WheelController:
     """
     Base class for wheel balancers.
 
@@ -45,6 +45,7 @@ class WheelBalancer:
     integral_error_velocity: float
     max_target_accel: float
     max_target_velocity: float
+    sagittal_balancer: SagittalBalancer
     target_ground_velocity: float
     target_yaw_velocity: float
     turning_deadband: float

--- a/pink_balancer/wheel_controller.py
+++ b/pink_balancer/wheel_controller.py
@@ -114,7 +114,7 @@ class WheelController:
         )
         return log_dict
 
-    def cycle(self, observation: dict, dt: float) -> None:
+    def cycle(self, observation: dict, dt: float) -> dict:
         """
         Compute a new ground velocity.
 

--- a/pink_balancer/wheel_controller.py
+++ b/pink_balancer/wheel_controller.py
@@ -53,7 +53,7 @@ class WheelController:
 
     def __init__(
         self,
-        balancer_class: str,
+        balancer_class: Literal["MPCBalancer", "PIBalancer"],
         max_target_accel: float,
         max_target_velocity: float,
         max_yaw_accel: float,

--- a/pink_balancer/wheel_controller.py
+++ b/pink_balancer/wheel_controller.py
@@ -66,6 +66,8 @@ class WheelController:
         Initialize balancer.
 
         Args:
+            balancer_class: String indicating the SagittalBalancer class to
+                instantiate.
             max_target_accel: Maximum acceleration for the ground target, in
                 [m] / [s]². This bound does not affect the commanded ground
                 velocity.

--- a/pink_balancer/whole_body_controller.py
+++ b/pink_balancer/whole_body_controller.py
@@ -65,7 +65,6 @@ class WholeBodyController:
             "right_knee": leg_action["servo"]["right_knee"],
             "right_wheel": wheel_action["servo"]["right_wheel"],
         }
-
         turning_prob = self.wheel_balancer.turning_probability
         kp_scale = self.gain_scale + self.turning_gain_scale * turning_prob
         kd_scale = self.gain_scale + self.turning_gain_scale * turning_prob

--- a/pink_balancer/whole_body_controller.py
+++ b/pink_balancer/whole_body_controller.py
@@ -9,7 +9,7 @@ import gin
 from upkie.utils.clamp import clamp
 
 from .height_controller import HeightController
-from .pi_wheel_balancer import PIWheelBalancer
+from .wheel_balancer import WheelBalancer
 
 
 @gin.configurable
@@ -42,7 +42,7 @@ class WholeBodyController:
         self.gain_scale = clamp(gain_scale, 0.1, 2.0)
         self.height_controller = HeightController(visualize=visualize)
         self.turning_gain_scale = turning_gain_scale
-        self.wheel_balancer = PIWheelBalancer()
+        self.wheel_balancer = WheelBalancer()
 
     def cycle(self, observation: dict, dt: float) -> dict:
         """

--- a/pink_balancer/whole_body_controller.py
+++ b/pink_balancer/whole_body_controller.py
@@ -7,9 +7,9 @@
 
 import gin
 from upkie.utils.clamp import clamp
-from .wheel_balancer import WheelBalancer
 
 from .height_controller import HeightController
+from .pi_wheel_balancer import PIWheelBalancer
 
 
 @gin.configurable
@@ -19,13 +19,11 @@ class WholeBodyController:
 
     Attributes:
         gain_scale: PD gain scale for hip and knee joints.
-        tasks: Dictionary of inverse kinematics tasks.
         turning_gain_scale: Additional gain scale added when the robot is
             turning to keep the legs stiff while the ground pulls them apart.
     """
 
     gain_scale: float
-    tasks: dict
     turning_gain_scale: float
 
     def __init__(
@@ -44,7 +42,7 @@ class WholeBodyController:
         self.gain_scale = clamp(gain_scale, 0.1, 2.0)
         self.height_controller = HeightController(visualize=visualize)
         self.turning_gain_scale = turning_gain_scale
-        self.wheel_balancer = WheelBalancer()  # type: ignore
+        self.wheel_balancer = PIWheelBalancer()
 
     def cycle(self, observation: dict, dt: float) -> dict:
         """

--- a/run_agent.py
+++ b/run_agent.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     spine = SpineInterface(retries=10)
     controller = WholeBodyController(visualize=args.visualize)
     spine_config = upkie.config.SPINE_CONFIG.copy()
-    wheel_radius = controller.wheel_balancer.wheel_radius
+    wheel_radius = controller.wheel_controller.wheel_radius
     wheel_odometry_config = spine_config["wheel_odometry"]
     wheel_odometry_config["signed_radius"]["left_wheel"] = +wheel_radius
     wheel_odometry_config["signed_radius"]["right_wheel"] = -wheel_radius


### PR DESCRIPTION
This PR refactors the `WheelBalancer` into a `WheelController` owning a `SagittalBalancer` that only outputs a sagittal ground velocity for balancing. Balancers are located in `pink_balancer.sagittal_balance`, and there are now two of them:

- `PIBalancer`: the former one
- `MPCBalancer`: adapted from the [MPC balancer](https://github.com/upkie/mpc_balancer)

We can select the MPC or PI sagittal balancer by setting `WheelController.balancer_class` in the gin config.